### PR TITLE
Remove sized requirement from Function::get_stats

### DIFF
--- a/ph/src/fmph/function.rs
+++ b/ph/src/fmph/function.rs
@@ -372,7 +372,7 @@ impl<S: BuildSeededHasher> GetSize for Function<S> {
 impl<S: BuildSeededHasher> Function<S> {
 
     /// Returns index of the key `k` at the level of the given number (`level_nr`) and `size`.
-    #[inline(always)] fn index<K: Hash>(&self, k: &K, level_nr: u32, size: usize) -> usize {
+    #[inline(always)] fn index<K: Hash + ?Sized>(&self, k: &K, level_nr: u32, size: usize) -> usize {
         //utils::map64_to_32(self.hash_builder.hash_one(k, level_nr), size as u32) as usize
         utils::map64_to_64(self.hash_builder.hash_one(k, level_nr), size as u64) as usize
     }
@@ -381,7 +381,7 @@ impl<S: BuildSeededHasher> Function<S> {
     /// 
     /// The returned value is in the range: `0` (inclusive), the number of elements in the input key collection (exclusive).
     /// If the `key` was not in the input key collection, either `None` or an undetermined value from the specified range is returned.
-    pub fn get_stats<K: Hash, A: stats::AccessStatsCollector>(&self, key: &K, access_stats: &mut A) -> Option<u64> {
+    pub fn get_stats<K: Hash + ?Sized, A: stats::AccessStatsCollector>(&self, key: &K, access_stats: &mut A) -> Option<u64> {
         let mut array_begin_index = 0usize;
         let mut level_nr = 0u32;
         loop {
@@ -400,7 +400,7 @@ impl<S: BuildSeededHasher> Function<S> {
     /// 
     /// The returned value is in the range: `0` (inclusive), the number of elements in the input key collection (exclusive).
     /// If the `key` was not in the input key collection, either `None` or an undetermined value from the specified range is returned.
-    #[inline] pub fn get<K: Hash>(&self, key: &K) -> Option<u64> {
+    #[inline] pub fn get<K: Hash + ?Sized>(&self, key: &K) -> Option<u64> {
         self.get_stats(key, &mut ())
     }
 

--- a/ph/src/fmph/gofunction.rs
+++ b/ph/src/fmph/gofunction.rs
@@ -426,7 +426,7 @@ impl<GS: GroupSize, SS: SeedSize, S: BuildSeededHasher> GOFunction<GS, SS, S> {
     /// 
     /// The returned value is in the range: `0` (inclusive), the number of elements in the input key collection (exclusive).
     /// If the `key` was not in the input key collection, either `None` or an undetermined value from the specified range is returned.
-    pub fn get_stats<K: Hash, A: stats::AccessStatsCollector>(&self, key: &K, access_stats: &mut A) -> Option<u64> {
+    pub fn get_stats<K: Hash + ?Sized, A: stats::AccessStatsCollector>(&self, key: &K, access_stats: &mut A) -> Option<u64> {
         let mut groups_before = 0u64;
         let mut level_nr = 0u32;
         loop {
@@ -451,7 +451,7 @@ impl<GS: GroupSize, SS: SeedSize, S: BuildSeededHasher> GOFunction<GS, SS, S> {
     /// 
     /// The returned value is in the range: `0` (inclusive), the number of elements in the input key collection (exclusive).
     /// If the `key` was not in the input key collection, either `None` or an undetermined value from the specified range is returned.
-    #[inline] pub fn get<K: Hash>(&self, key: &K) -> Option<u64> {
+    #[inline] pub fn get<K: Hash + ?Sized>(&self, key: &K) -> Option<u64> {
         self.get_stats(key, &mut ())
     }
 


### PR DESCRIPTION
Hi!

This is a small patch that removes the implicit `Sized` requirement from `Function::get_stats` and `GOFunction::get_stats` (as well as their `get` equivalents).

As far as I can tell, this shouldn't have any negative impact on their functioning, and makes them more suited to being used in maps (which will often be indexed by the unsized `str`).

Thank you for the attention!