### PR TITLE
Switch to prefetch_index crate

### DIFF
--- a/bitm/Cargo.toml
+++ b/bitm/Cargo.toml
@@ -14,6 +14,7 @@ keywords = [ "bit", "bitmap", "rank", "bitvector", "bitset" ]
 [dependencies]
 dyn_size_of = { version=">=0.4.3", path="../dyn_size_of" }
 aligned-vec = { version="0.6", optional=true }  # for construcing cache-aligment bit vectors, which usually speeds up rank and select
+prefetch-index = "0.1.0"
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
Ugh; my `prefetch_index` implementation was completely broken for aarch64 and needs nightly there.

I moved it to a separate crate now so it's easily reused and put the aarch64 functionality behind the `aarch64` feature flag in case you don't mind requiring nightly.
