### PR TITLE
Update benchmarks to sux 0.14.0

### DIFF
--- a/cseq_benchmark/.cargo/config.toml
+++ b/cseq_benchmark/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]
+
+[target.wasm32-wasip1]
+runner = "wasmtime"

--- a/cseq_benchmark/Cargo.toml
+++ b/cseq_benchmark/Cargo.toml
@@ -23,5 +23,5 @@ vers-vecs = { version="1.1", optional=true }
 [target.'cfg(target_pointer_width = "64")'.dependencies]
 sucds = "0.8"
 succinct = "0.5"
-sux="0.6"
-mem_dbg = "0.3" # required by sux MemSize
+sux= { git = "https://github.com/vigna/sux-rs" }
+mem_dbg = "0.4" # required by sux MemSize

--- a/cseq_benchmark/Cargo.toml
+++ b/cseq_benchmark/Cargo.toml
@@ -23,5 +23,5 @@ vers-vecs = { version="1.1", optional=true }
 [target.'cfg(target_pointer_width = "64")'.dependencies]
 sucds = "0.8"
 succinct = "0.5"
-sux= { git = "https://github.com/vigna/sux-rs" }
+sux= "0.14.0"
 mem_dbg = "0.4" # required by sux MemSize

--- a/cseq_benchmark/src/main.rs
+++ b/cseq_benchmark/src/main.rs
@@ -43,22 +43,22 @@ pub enum Structure {
     SuccinctRank9,
     /// Rank9 on uncompressed bit vector using sux crate
     SuxRank9,
-    /// RankSmall[u64:2] on uncompressed bit vector using sux crate
+    /// RsSmall[u64:2] on uncompressed bit vector using sux crate
     #[cfg(target_pointer_width = "64")]
     #[clap(visible_alias = "sux-rs-u64-2")]
-    SuxRankSmallU64v2,
-    /// RankSmall[u64:3] on uncompressed bit vector using sux crate
+    SuxRsSmallU64v2,
+    /// RsSmall[u64:3] on uncompressed bit vector using sux crate
     #[cfg(target_pointer_width = "64")]
     #[clap(visible_alias = "sux-rs-u64-3")]
-    SuxRankSmallU64v3,
-    /// RankSmall[u32:3] on uncompressed bit vector using sux crate
+    SuxRsSmallU64v3,
+    /// RsSmall[u32:3] on uncompressed bit vector using sux crate
     #[cfg(not(target_pointer_width = "64"))]
     #[clap(visible_alias = "sux-rs-u32-3")]
-    SuxRankSmallU32v3,
-    /// RankSmall[u32:4] on uncompressed bit vector using sux crate
+    SuxRsSmallU32v3,
+    /// RsSmall[u32:4] on uncompressed bit vector using sux crate
     #[cfg(not(target_pointer_width = "64"))]
     #[clap(visible_alias = "sux-rs-u32-4")]
-    SuxRankSmallU32v4,
+    SuxRsSmallU32v4,
     /// SelectAdapt (default) on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt")]
     SuxSelectAdapt,
@@ -641,13 +641,13 @@ fn main() {
         Structure::SuccinctRank9 => succinct::benchmark_rank9(&conf),
         Structure::SuxRank9 => sux::benchmark_rank9(&conf),
         #[cfg(target_pointer_width = "64")]
-        Structure::SuxRankSmallU64v2 => sux::benchmark_rank_small_u64_2(&conf),
+        Structure::SuxRsSmallU64v2 => sux::benchmark_rs_small_u64_2(&conf),
         #[cfg(target_pointer_width = "64")]
-        Structure::SuxRankSmallU64v3 => sux::benchmark_rank_small_u64_3(&conf),
+        Structure::SuxRsSmallU64v3 => sux::benchmark_rs_small_u64_3(&conf),
         #[cfg(not(target_pointer_width = "64"))]
-        Structure::SuxRankSmallU32v3 => sux::benchmark_rank_small_u32_3(&conf),
+        Structure::SuxRsSmallU32v3 => sux::benchmark_rs_small_u32_3(&conf),
         #[cfg(not(target_pointer_width = "64"))]
-        Structure::SuxRankSmallU32v4 => sux::benchmark_rank_small_u32_4(&conf),
+        Structure::SuxRsSmallU32v4 => sux::benchmark_rs_small_u32_4(&conf),
         Structure::SuxSelectAdapt => sux::benchmark_select_adapt(&conf),
         Structure::SuxSelectAdaptSparser => sux::benchmark_select_adapt_sparser(&conf),
         Structure::SuxSelectAdaptSparsest => sux::benchmark_select_adapt_sparsest(&conf),
@@ -666,13 +666,13 @@ fn main() {
             vers::benchmark_rank_select(&conf);
             sux::benchmark_rank9(&conf);
             #[cfg(target_pointer_width = "64")]
-            sux::benchmark_rank_small_u64_2(&conf);
+            sux::benchmark_rs_small_u64_2(&conf);
             #[cfg(target_pointer_width = "64")]
-            sux::benchmark_rank_small_u64_3(&conf);
+            sux::benchmark_rs_small_u64_3(&conf);
             #[cfg(not(target_pointer_width = "64"))]
-            sux::benchmark_rank_small_u32_3(&conf);
+            sux::benchmark_rs_small_u32_3(&conf);
             #[cfg(not(target_pointer_width = "64"))]
-            sux::benchmark_rank_small_u32_4(&conf);
+            sux::benchmark_rs_small_u32_4(&conf);
             sux::benchmark_select_adapt(&conf);
             sux::benchmark_select_adapt_sparser(&conf);
             sux::benchmark_select_adapt_sparsest(&conf);

--- a/cseq_benchmark/src/main.rs
+++ b/cseq_benchmark/src/main.rs
@@ -4,7 +4,7 @@ mod elias_fano;
 mod bitm;
 #[cfg(target_pointer_width = "64")] mod sucds;
 #[cfg(target_pointer_width = "64")] mod succinct;
-#[cfg(target_pointer_width = "64")] mod sux;
+mod sux;
 #[cfg(feature = "vers-vecs")] mod vers;
 
 use std::{fs::{File, OpenOptions}, hint::black_box, num::{NonZeroU32, NonZeroU64}, ops::Range, time::Instant};
@@ -31,12 +31,35 @@ pub enum Structure {
     #[cfg(target_pointer_width = "64")]
     #[clap(visible_aliases = ["succ-rank9", "succ-r9"])]
     SuccinctRank9,
-    /// SelectFixed1 on uncompressed bit vector using sux crate
+    /// Rank9 on uncompressed bit vector using sux crate
+    #[clap(visible_alias = "sux-rank9")]
+    SuxRank9,
+    /// RankSmall[u64:2] on uncompressed bit vector using sux crate
     #[cfg(target_pointer_width = "64")]
+    #[clap(visible_alias = "sux-rs-u64-2")]
+    SuxRankSmallU64v2,
+    /// RankSmall[u64:3] on uncompressed bit vector using sux crate
+    #[cfg(target_pointer_width = "64")]
+    #[clap(visible_alias = "sux-rs-u64-3")]
+    SuxRankSmallU64v3,
+    /// RankSmall[u32:3] on uncompressed bit vector using sux crate
+    #[cfg(not(target_pointer_width = "64"))]
+    #[clap(visible_alias = "sux-rs-u32-3")]
+    SuxRankSmallU32v3,
+    /// RankSmall[u32:4] on uncompressed bit vector using sux crate
+    #[cfg(not(target_pointer_width = "64"))]
+    #[clap(visible_alias = "sux-rs-u32-4")]
+    SuxRankSmallU32v4,
+    /// SelectAdapt on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt")]
     SuxSelectAdapt,
-    /// SelectFixed2 on uncompressed bit vector using sux crate
-    #[cfg(target_pointer_width = "64")]
+    /// SelectAdapt with span-1 on uncompressed bit vector using sux crate
+    #[clap(visible_alias = "sux-adapt-m1")]
+    SuxSelectAdaptM1,
+    /// SelectAdapt with span-2 on uncompressed bit vector using sux crate
+    #[clap(visible_alias = "sux-adapt-m2")]
+    SuxSelectAdaptM2,
+    /// SelectAdaptConst on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt-const")]
     SuxSelectAdaptConst,
     /// Rank/Select on uncompressed bit vector using vers crate
@@ -442,8 +465,15 @@ fn main() {
         #[cfg(target_pointer_width = "64")] Structure::SucdsBV => sucds::benchmark_rank9_select(&conf),
         #[cfg(target_pointer_width = "64")] Structure::SuccinctJacobson => succinct::benchmark_jacobson(&conf),
         #[cfg(target_pointer_width = "64")] Structure::SuccinctRank9 => succinct::benchmark_rank9(&conf),
-        #[cfg(target_pointer_width = "64")] Structure::SuxSelectAdapt => sux::benchmark_select_adapt_const(&conf),
-        #[cfg(target_pointer_width = "64")] Structure::SuxSelectAdaptConst => sux::benchmark_select_adapt(&conf),
+        Structure::SuxRank9 => sux::benchmark_rank9(&conf),
+        #[cfg(target_pointer_width = "64")] Structure::SuxRankSmallU64v2 => sux::benchmark_rank_small_u64_2(&conf),
+        #[cfg(target_pointer_width = "64")] Structure::SuxRankSmallU64v3 => sux::benchmark_rank_small_u64_3(&conf),
+        #[cfg(not(target_pointer_width = "64"))] Structure::SuxRankSmallU32v3 => sux::benchmark_rank_small_u32_3(&conf),
+        #[cfg(not(target_pointer_width = "64"))] Structure::SuxRankSmallU32v4 => sux::benchmark_rank_small_u32_4(&conf),
+        Structure::SuxSelectAdapt => sux::benchmark_select_adapt(&conf),
+        Structure::SuxSelectAdaptM1 => sux::benchmark_select_adapt_m1(&conf),
+        Structure::SuxSelectAdaptM2 => sux::benchmark_select_adapt_m2(&conf),
+        Structure::SuxSelectAdaptConst => sux::benchmark_select_adapt_const(&conf),
         #[cfg(feature = "vers-vecs")] Structure::Vers => vers::benchmark_rank_select(&conf),
         Structure::BV => {
             bitm::benchmark_rank_select(&conf);
@@ -453,10 +483,15 @@ fn main() {
             succinct::benchmark_jacobson(&conf);
             }
             #[cfg(feature = "vers-vecs")] vers::benchmark_rank_select(&conf);
-            #[cfg(target_pointer_width = "64")] {
+            sux::benchmark_rank9(&conf);
+            #[cfg(target_pointer_width = "64")] sux::benchmark_rank_small_u64_2(&conf);
+            #[cfg(target_pointer_width = "64")] sux::benchmark_rank_small_u64_3(&conf);
+            #[cfg(not(target_pointer_width = "64"))] sux::benchmark_rank_small_u32_3(&conf);
+            #[cfg(not(target_pointer_width = "64"))] sux::benchmark_rank_small_u32_4(&conf);
             sux::benchmark_select_adapt(&conf);
+            sux::benchmark_select_adapt_m1(&conf);
+            sux::benchmark_select_adapt_m2(&conf);
             sux::benchmark_select_adapt_const(&conf);
-            }
         },
     }
 }

--- a/cseq_benchmark/src/main.rs
+++ b/cseq_benchmark/src/main.rs
@@ -43,6 +43,10 @@ pub enum Structure {
     SuccinctRank9,
     /// Rank9 on uncompressed bit vector using sux crate
     SuxRank9,
+    /// RsSmall[u64:2] on uncompressed bit vector using sux crate
+    #[cfg(target_pointer_width = "64")]
+    #[clap(visible_alias = "sux-rs-u64-2")]
+    SuxRsSmallU64v2,
     /// RsSmall[u64:3] on uncompressed bit vector using sux crate
     #[cfg(target_pointer_width = "64")]
     #[clap(visible_alias = "sux-rs-u64-3")]
@@ -51,6 +55,10 @@ pub enum Structure {
     #[cfg(target_pointer_width = "64")]
     #[clap(visible_alias = "sux-rs-u64-4")]
     SuxRsSmallU64v4,
+    /// RsSmall[u32:3] on uncompressed bit vector using sux crate
+    #[cfg(not(target_pointer_width = "64"))]
+    #[clap(visible_alias = "sux-rs-u32-3")]
+    SuxRsSmallU32v3,
     /// RsSmall[u32:4] on uncompressed bit vector using sux crate
     #[cfg(not(target_pointer_width = "64"))]
     #[clap(visible_alias = "sux-rs-u32-4")]
@@ -641,9 +649,13 @@ fn main() {
         Structure::SuccinctRank9 => succinct::benchmark_rank9(&conf),
         Structure::SuxRank9 => sux::benchmark_rank9(&conf),
         #[cfg(target_pointer_width = "64")]
+        Structure::SuxRsSmallU64v2 => sux::benchmark_rs_small_u64_2(&conf),
+        #[cfg(target_pointer_width = "64")]
         Structure::SuxRsSmallU64v3 => sux::benchmark_rs_small_u64_3(&conf),
         #[cfg(target_pointer_width = "64")]
         Structure::SuxRsSmallU64v4 => sux::benchmark_rs_small_u64_4(&conf),
+        #[cfg(not(target_pointer_width = "64"))]
+        Structure::SuxRsSmallU32v3 => sux::benchmark_rs_small_u32_3(&conf),
         #[cfg(not(target_pointer_width = "64"))]
         Structure::SuxRsSmallU32v4 => sux::benchmark_rs_small_u32_4(&conf),
         #[cfg(not(target_pointer_width = "64"))]
@@ -666,9 +678,13 @@ fn main() {
             vers::benchmark_rank_select(&conf);
             sux::benchmark_rank9(&conf);
             #[cfg(target_pointer_width = "64")]
+            sux::benchmark_rs_small_u64_2(&conf);
+            #[cfg(target_pointer_width = "64")]
             sux::benchmark_rs_small_u64_3(&conf);
             #[cfg(target_pointer_width = "64")]
             sux::benchmark_rs_small_u64_4(&conf);
+            #[cfg(not(target_pointer_width = "64"))]
+            sux::benchmark_rs_small_u32_3(&conf);
             #[cfg(not(target_pointer_width = "64"))]
             sux::benchmark_rs_small_u32_4(&conf);
             #[cfg(not(target_pointer_width = "64"))]

--- a/cseq_benchmark/src/main.rs
+++ b/cseq_benchmark/src/main.rs
@@ -64,10 +64,10 @@ pub enum Structure {
     SuxSelectAdapt,
     /// SelectAdapt with sparser inventory on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt-sparser")]
-    SuxSelectAdaptP1,
+    SuxSelectAdaptSparser,
     /// SelectAdapt with sparsest inventory on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt-sparsest")]
-    SuxSelectAdaptP2,
+    SuxSelectAdaptSparsest,
     /// SelectAdaptConst on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt-const")]
     SuxSelectAdaptConst,
@@ -649,8 +649,8 @@ fn main() {
         #[cfg(not(target_pointer_width = "64"))]
         Structure::SuxRankSmallU32v4 => sux::benchmark_rank_small_u32_4(&conf),
         Structure::SuxSelectAdapt => sux::benchmark_select_adapt(&conf),
-        Structure::SuxSelectAdaptP1 => sux::benchmark_select_adapt_p1(&conf),
-        Structure::SuxSelectAdaptP2 => sux::benchmark_select_adapt_p2(&conf),
+        Structure::SuxSelectAdaptSparser => sux::benchmark_select_adapt_sparser(&conf),
+        Structure::SuxSelectAdaptSparsest => sux::benchmark_select_adapt_sparsest(&conf),
         Structure::SuxSelectAdaptConst => sux::benchmark_select_adapt_const(&conf),
         #[cfg(feature = "vers-vecs")]
         Structure::Vers => vers::benchmark_rank_select(&conf),
@@ -674,8 +674,8 @@ fn main() {
             #[cfg(not(target_pointer_width = "64"))]
             sux::benchmark_rank_small_u32_4(&conf);
             sux::benchmark_select_adapt(&conf);
-            sux::benchmark_select_adapt_p1(&conf);
-            sux::benchmark_select_adapt_p2(&conf);
+            sux::benchmark_select_adapt_sparser(&conf);
+            sux::benchmark_select_adapt_sparsest(&conf);
             sux::benchmark_select_adapt_const(&conf);
         }
     }

--- a/cseq_benchmark/src/main.rs
+++ b/cseq_benchmark/src/main.rs
@@ -1,14 +1,23 @@
 #![doc = include_str!("../README.md")]
 
-mod elias_fano;
 mod bitm;
-#[cfg(target_pointer_width = "64")] mod sucds;
-#[cfg(target_pointer_width = "64")] mod succinct;
+mod elias_fano;
+#[cfg(target_pointer_width = "64")]
+mod succinct;
+#[cfg(target_pointer_width = "64")]
+mod sucds;
 mod sux;
-#[cfg(feature = "vers-vecs")] mod vers;
+#[cfg(feature = "vers-vecs")]
+mod vers;
 
-use std::{fs::{File, OpenOptions}, hint::black_box, num::{NonZeroU32, NonZeroU64}, ops::Range, time::Instant};
 use std::io::Write;
+use std::{
+    fs::{File, OpenOptions},
+    hint::black_box,
+    num::{NonZeroU32, NonZeroU64},
+    ops::Range,
+    time::Instant,
+};
 
 use butils::{UnitPrefix, XorShift64};
 use clap::{Parser, Subcommand, ValueEnum};
@@ -22,7 +31,8 @@ pub enum Structure {
     /// Rank/Select on uncompressed bit vector using bitm crate
     BitmBV,
     /// Rank/Select on uncompressed bit vector using sucds crate
-    #[cfg(target_pointer_width = "64")] SucdsBV,
+    #[cfg(target_pointer_width = "64")]
+    SucdsBV,
     /// Rank/Select on uncompressed bit vector using Jacobson from succinct crate
     #[cfg(target_pointer_width = "64")]
     #[clap(visible_alias = "succ-jacobson")]
@@ -32,7 +42,6 @@ pub enum Structure {
     #[clap(visible_aliases = ["succ-rank9", "succ-r9"])]
     SuccinctRank9,
     /// Rank9 on uncompressed bit vector using sux crate
-    #[clap(visible_alias = "sux-rank9")]
     SuxRank9,
     /// RankSmall[u64:2] on uncompressed bit vector using sux crate
     #[cfg(target_pointer_width = "64")]
@@ -50,22 +59,23 @@ pub enum Structure {
     #[cfg(not(target_pointer_width = "64"))]
     #[clap(visible_alias = "sux-rs-u32-4")]
     SuxRankSmallU32v4,
-    /// SelectAdapt on uncompressed bit vector using sux crate
+    /// SelectAdapt (default) on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt")]
     SuxSelectAdapt,
-    /// SelectAdapt with span-1 on uncompressed bit vector using sux crate
-    #[clap(visible_alias = "sux-adapt-m1")]
-    SuxSelectAdaptM1,
-    /// SelectAdapt with span-2 on uncompressed bit vector using sux crate
-    #[clap(visible_alias = "sux-adapt-m2")]
-    SuxSelectAdaptM2,
+    /// SelectAdapt with sparser inventory on uncompressed bit vector using sux crate
+    #[clap(visible_alias = "sux-adapt-sparser")]
+    SuxSelectAdaptP1,
+    /// SelectAdapt with sparsest inventory on uncompressed bit vector using sux crate
+    #[clap(visible_alias = "sux-adapt-sparsest")]
+    SuxSelectAdaptP2,
     /// SelectAdaptConst on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt-const")]
     SuxSelectAdaptConst,
     /// Rank/Select on uncompressed bit vector using vers crate
-    #[cfg(feature = "vers-vecs")] Vers,
+    #[cfg(feature = "vers-vecs")]
+    Vers,
     /// Rank and select on bit vectors using all supported methods and crates
-    BV
+    BV,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -83,11 +93,15 @@ pub enum Distribution {
 
 impl std::fmt::Display for Distribution {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match *self {
-            Distribution::Uniform => "uniform",
-            Distribution::Adversarial => "adversarial",
-            Distribution::LinearlyDensified => "linearly densified",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                Distribution::Uniform => "uniform",
+                Distribution::Adversarial => "adversarial",
+                Distribution::LinearlyDensified => "linearly densified",
+            }
+        )
     }
 }
 
@@ -112,11 +126,11 @@ pub struct Conf {
     pub distribution: Distribution,
 
     /// Time (in seconds) of measuring and warming up the CPU cache before measuring
-    #[arg(short='t', long, default_value_t = 5)]
+    #[arg(short = 't', long, default_value_t = 5)]
     pub time: u16,
 
     /// Time (in seconds) of cooling (sleeping) before warming up and measuring
-    #[arg(short='c', long, default_value_t = 0)]
+    #[arg(short = 'c', long, default_value_t = 0)]
     pub cooling_time: u16,
 
     /// Whether to check the validity of built sequence
@@ -132,7 +146,7 @@ pub struct Conf {
     pub queries: NonZeroU32,
 
     /// Save detailed results to CSV file(s)
-    #[arg(short='f', long, default_value_t = false)]
+    #[arg(short = 'f', long, default_value_t = false)]
     pub save_details: bool,
 }
 
@@ -147,38 +161,63 @@ struct Tester<'c> {
     /// Real number of ones/items.
     number_of_ones: usize,
     /// Needed for validation of `rank` operation; 'false' by default, but can be changed after construction.
-    rank_includes_current: bool
+    rank_includes_current: bool,
 }
 
 /// Prints a message if `expected` differs from `got` and puts `structure_name`, `operation_name` and `argument` in the message,
-fn check<R: Into<Option<usize>>>(structure_name: &str, operation_name: &str, argument: usize, expected: usize, got: R) {
+fn check<R: Into<Option<usize>>>(
+    structure_name: &str,
+    operation_name: &str,
+    argument: usize,
+    expected: usize,
+    got: R,
+) {
     if let Some(got) = got.into() {
         if got != expected {
             eprintln!("{structure_name}: {operation_name}({argument}) returned {got}, but should {expected}");
         }
     } else {
-        eprintln!("{structure_name}: {operation_name}({argument}) returned None, but should {expected}")
+        eprintln!(
+            "{structure_name}: {operation_name}({argument}) returned None, but should {expected}"
+        )
     }
 }
 
 impl<'c> Tester<'c> {
     /// Tests function answering `rank` queries. Reports its speed and potentially validates.
-    #[inline(always)] pub fn raport_rank<R: Into<Option<usize>>, F>(&self, method_name: &str, size_bytes: usize, rank: F)
-    where F: Fn(usize) -> R
+    #[inline(always)]
+    pub fn raport_rank<R: Into<Option<usize>>, F>(
+        &self,
+        method_name: &str,
+        size_bytes: usize,
+        rank: F,
+    ) where
+        F: Fn(usize) -> R,
     {
-        print!("  rank:  space overhead {:.2}%", self.conf.space_overhead(size_bytes));
-        let time = self.conf.queries_measure(&self.conf.rand_queries(self.conf.universe), &rank).as_nanos();
+        print!(
+            "  rank:  space overhead {:.2}%",
+            self.conf.space_overhead(size_bytes)
+        );
+        let time = self
+            .conf
+            .queries_measure(&self.conf.rand_queries(self.conf.universe), &rank)
+            .as_nanos();
         println!("  time/query {:.2}ns", time);
         self.conf.save_rank(method_name, size_bytes, time);
         self.verify_rank(method_name, rank);
     }
 
     /// If verification flag is set, validates function answering `rank` queries using all points of the universe.
-    fn verify_rank<R: Into<Option<usize>>, F>(&self, method_name: &str, rank: F) where F: Fn(usize) -> R {
+    fn verify_rank<R: Into<Option<usize>>, F>(&self, method_name: &str, rank: F)
+    where
+        F: Fn(usize) -> R,
+    {
         if self.conf.verify {
             //print!("   verification of rank answers... ");
             self.conf.data_foreach(|index, mut expected_rank, value| {
-                if self.rank_includes_current && value { expected_rank += 1 }
+                if self.rank_includes_current && value {
+                    expected_rank += 1
+                }
                 check(method_name, "rank", index, expected_rank, rank(index))
             });
             //println!("DONE");
@@ -186,57 +225,98 @@ impl<'c> Tester<'c> {
     }
 
     /// Tests function answering `select` (one) queries. Reports its speed and potentially validates.
-    #[inline(always)] pub fn raport_select1<R: Into<Option<usize>>, F>(&self, method_name: &str, extra_size_bytes: usize, select: F)
-    where F: Fn(usize) -> R
+    #[inline(always)]
+    pub fn raport_select1<R: Into<Option<usize>>, F>(
+        &self,
+        method_name: &str,
+        extra_size_bytes: usize,
+        select: F,
+    ) where
+        F: Fn(usize) -> R,
     {
         if self.number_of_ones == 0 {
             //println!("skipping select1 test as there are no ones");
             return;
         }
         print!("  select1:");
-        if extra_size_bytes != 0 { print!("  space overhead {:.2}%", self.conf.extra_space_overhead(extra_size_bytes)); }
-        let time = self.conf.queries_measure(&self.conf.rand_queries(self.number_of_ones), &select).as_nanos();
+        if extra_size_bytes != 0 {
+            print!(
+                "  space overhead {:.2}%",
+                self.conf.extra_space_overhead(extra_size_bytes)
+            );
+        }
+        let time = self
+            .conf
+            .queries_measure(&self.conf.rand_queries(self.number_of_ones), &select)
+            .as_nanos();
         println!("  time/query {:.2}ns", time);
         self.conf.save_select1(method_name, extra_size_bytes, time);
         self.verify_select1(method_name, select);
     }
 
     /// If verification flag is set, validates function answering `select` (one) queries using all ones in the universe.
-    fn verify_select1<R: Into<Option<usize>>, F>(&self, method_name: &str, select: F) where F: Fn(usize) -> R {
+    fn verify_select1<R: Into<Option<usize>>, F>(&self, method_name: &str, select: F)
+    where
+        F: Fn(usize) -> R,
+    {
         if self.conf.verify {
             //print!("   verification of select1 answers... ");
-            self.conf.data_foreach(|index, rank, value| if value {
-                check(method_name, "select", rank, index, select(rank))
+            self.conf.data_foreach(|index, rank, value| {
+                if value {
+                    check(method_name, "select", rank, index, select(rank))
+                }
             });
             //println!("DONE");
         }
     }
 
     /// Tests function answering `select0` queries. Reports its speed and potentially validates.
-    #[inline(always)] pub fn raport_select0<R: Into<Option<usize>>, F>(&self, method_name: &str, extra_size_bytes: usize, select0: F)
-    where F: Fn(usize) -> R
+    #[inline(always)]
+    pub fn raport_select0<R: Into<Option<usize>>, F>(
+        &self,
+        method_name: &str,
+        extra_size_bytes: usize,
+        select0: F,
+    ) where
+        F: Fn(usize) -> R,
     {
         if self.conf.universe == self.number_of_ones {
             //println!("skipping select0 test as there are no zeros");
             return;
         }
         print!("  select0:");
-        if extra_size_bytes != 0 { print!("  space overhead {:.2}%", self.conf.extra_space_overhead(extra_size_bytes)); }
-        let time = self.conf.queries_measure(
-            &self.conf.rand_queries(self.conf.universe-self.number_of_ones),
-            &select0).as_nanos();
+        if extra_size_bytes != 0 {
+            print!(
+                "  space overhead {:.2}%",
+                self.conf.extra_space_overhead(extra_size_bytes)
+            );
+        }
+        let time = self
+            .conf
+            .queries_measure(
+                &self
+                    .conf
+                    .rand_queries(self.conf.universe - self.number_of_ones),
+                &select0,
+            )
+            .as_nanos();
         println!("  time/query {:.2}ns", time);
         self.conf.save_select0(method_name, extra_size_bytes, time);
         self.verify_select0(method_name, select0);
     }
 
     /// If verification flag is set, validates function answering `select0` queries using all zeros in the universe.
-    fn verify_select0<R: Into<Option<usize>>, F>(&self, method_name: &str, select0: F) where F: Fn(usize) -> R {
+    fn verify_select0<R: Into<Option<usize>>, F>(&self, method_name: &str, select0: F)
+    where
+        F: Fn(usize) -> R,
+    {
         if self.conf.verify {
             //print!("   verification of select0 answers... ");
-            self.conf.data_foreach(|index, rank1, value| if !value {
-                let rank0 = index - rank1;
-                check(method_name, "select0", rank0, index, select0(rank0))
+            self.conf.data_foreach(|index, rank1, value| {
+                if !value {
+                    let rank0 = index - rank1;
+                    check(method_name, "select0", rank0, index, select0(rank0))
+                }
             });
             //println!("DONE");
         }
@@ -244,7 +324,15 @@ impl<'c> Tester<'c> {
 }
 
 impl Conf {
-    #[inline(always)] fn uniform_foreach<F: FnMut(usize, usize, bool)>(&self, mut f: F, gen: &mut XorShift64, total_ones: &mut usize, mut num: usize, universe: Range<usize>) {
+    #[inline(always)]
+    fn uniform_foreach<F: FnMut(usize, usize, bool)>(
+        &self,
+        mut f: F,
+        gen: &mut XorShift64,
+        total_ones: &mut usize,
+        mut num: usize,
+        universe: Range<usize>,
+    ) {
         let mut remain_universe = universe.len();
         for i in universe {
             let included = gen.get() as usize % remain_universe < num;
@@ -260,8 +348,8 @@ impl Conf {
     /// Returns real number of items, usually close to `self.num`.
     fn num(&self) -> usize {
         match self.distribution {
-            Distribution::Uniform|Distribution::Adversarial => self.num,
-            Distribution::LinearlyDensified => { self.data_foreach(|_, _, _| {}) }
+            Distribution::Uniform | Distribution::Adversarial => self.num,
+            Distribution::LinearlyDensified => self.data_foreach(|_, _, _| {}),
         }
     }
 
@@ -282,30 +370,48 @@ impl Conf {
     /// - number of items (ones) before the current position,
     /// - whether there is an item (one) at the current position.
     /// Returns number of items (ones) in the whole universe.
-    #[inline(always)] fn data_foreach<F: FnMut(usize, usize, bool)>(&self, mut f: F) -> usize {
+    #[inline(always)]
+    fn data_foreach<F: FnMut(usize, usize, bool)>(&self, mut f: F) -> usize {
         let mut gen = self.rand_gen();
         let mut number_of_ones = 0;
 
         match self.distribution {
-            Distribution::Uniform => self.uniform_foreach(f, &mut gen, &mut number_of_ones, self.num, 0..self.universe),
+            Distribution::Uniform => {
+                self.uniform_foreach(f, &mut gen, &mut number_of_ones, self.num, 0..self.universe)
+            }
             Distribution::Adversarial => {
                 let sparse_threshold = self.universe - self.num;
-                self.uniform_foreach(&mut f, &mut gen, &mut number_of_ones, (self.num+50)/100, 0..sparse_threshold);
+                self.uniform_foreach(
+                    &mut f,
+                    &mut gen,
+                    &mut number_of_ones,
+                    (self.num + 50) / 100,
+                    0..sparse_threshold,
+                );
                 let num = self.num - number_of_ones;
-                self.uniform_foreach(f, &mut gen, &mut number_of_ones, num, sparse_threshold..self.universe);
+                self.uniform_foreach(
+                    f,
+                    &mut gen,
+                    &mut number_of_ones,
+                    num,
+                    sparse_threshold..self.universe,
+                );
             }
-            Distribution::LinearlyDensified => {    // linear density increase
+            Distribution::LinearlyDensified => {
+                // linear density increase
                 let (reverse, num_dbl) = if self.num * 2 > self.universe {
-                    (true, (self.universe - self.num)*2)
+                    (true, (self.universe - self.num) * 2)
                 } else {
-                    (false, self.num*2)
+                    (false, self.num * 2)
                 };
                 for i in 0..self.universe {
                     /*let remain_universe = self.universe - i;
                     let remain_num = num - number_of_ones;
                     let included = (gen.get() as usize % remain_universe * (remain_universe-1) < 2 * remain_num * i) ^ reverse;*/
                     let j = if reverse { self.universe - i } else { i };
-                    let included = (gen.get() as usize % self.universe * (self.universe-1) < num_dbl * j) ^ reverse;
+                    let included = (gen.get() as usize % self.universe * (self.universe - 1)
+                        < num_dbl * j)
+                        ^ reverse;
                     f(i, number_of_ones, included);
                     number_of_ones += included as usize;
                 }
@@ -320,33 +426,67 @@ impl Conf {
     /// Print statistics about data. Returns tester.
     fn fill_data<F: FnMut(usize, bool)>(&'_ self, mut add: F) -> Tester<'_> {
         let number_of_ones = self.data_foreach(|index, _, v| add(index, v));
-        println!(" input: number of bit ones is {} / {} ({:.2}%), {} distribution",
-            number_of_ones, self.universe, percent_of(number_of_ones, self.universe), self.distribution);
-        Tester { conf: self, number_of_ones, rank_includes_current: false }
+        println!(
+            " input: number of bit ones is {} / {} ({:.2}%), {} distribution",
+            number_of_ones,
+            self.universe,
+            percent_of(number_of_ones, self.universe),
+            self.distribution
+        );
+        Tester {
+            conf: self,
+            number_of_ones,
+            rank_includes_current: false,
+        }
     }
 
-    #[inline] fn add_data<F: FnMut(usize)>(&'_ self, mut add: F) -> Tester<'_> {
-        self.fill_data(|i, v| if v { add(i) })
+    #[inline]
+    fn add_data<F: FnMut(usize)>(&'_ self, mut add: F) -> Tester<'_> {
+        self.fill_data(|i, v| {
+            if v {
+                add(i)
+            }
+        })
     }
 
     /// Either opens or crates (and than put headers inside) and returns the file with given `file_name` (+`csv` extension).
     fn file(&self, file_name: &str, extra_header: &str) -> Option<File> {
-        if !self.save_details { return None; }
+        if !self.save_details {
+            return None;
+        }
         let file_name = format!("{}.csv", file_name);
         let file_already_existed = std::path::Path::new(&file_name).exists();
-        let mut file = OpenOptions::new().append(true).create(true).open(&file_name).unwrap();
-        if !file_already_existed { writeln!(file, "{},{}", INPUT_HEADER, extra_header).unwrap(); }
+        let mut file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&file_name)
+            .unwrap();
+        if !file_already_existed {
+            writeln!(file, "{},{}", INPUT_HEADER, extra_header).unwrap();
+        }
         Some(file)
     }
 
     /// Saves `space_overhead` and `time` per *rank* or *select* query (in ns) of method with given `method_name`
     /// to file with given `file_name` (+`csv` extension).
-    fn save_rank_or_select(&self, header: &str, file_name: &str, method_name: &str, space: usize, time: f64) {
+    fn save_rank_or_select(
+        &self,
+        header: &str,
+        file_name: &str,
+        method_name: &str,
+        space: usize,
+        time: f64,
+    ) {
         if let Some(mut file) = self.file(file_name, header) {
-            writeln!(file, "{},{},{},{},{},{}", self.universe, self.num, self.distribution, method_name, space, time).unwrap();
+            writeln!(
+                file,
+                "{},{},{},{},{},{}",
+                self.universe, self.num, self.distribution, method_name, space, time
+            )
+            .unwrap();
         }
     }
-    
+
     /// Saves `space_overhead` and `time` per *rank* query (in ns) of method with given `method_name` to `rank.csv`.
     pub fn save_rank(&self, method_name: &str, space_bytes: usize, time: f64) {
         self.save_rank_or_select(RANK_HEADER, "rank", method_name, space_bytes, time)
@@ -354,25 +494,44 @@ impl Conf {
 
     /// Saves `space_overhead` and `time` per *select1* query (in ns) of method with given `method_name` to `select1.csv`.
     pub fn save_select1(&self, method_name: &str, extra_size_bytes: usize, time: f64) {
-        self.save_rank_or_select(SELECT_HEADER, "select1", method_name, extra_size_bytes, time)
+        self.save_rank_or_select(
+            SELECT_HEADER,
+            "select1",
+            method_name,
+            extra_size_bytes,
+            time,
+        )
     }
 
     /// Saves `space_overhead` and `time` per *select0* query (in ns) of method with given `method_name` to `select0.csv`.
     pub fn save_select0(&self, method_name: &str, extra_size_bytes: usize, time: f64) {
-        self.save_rank_or_select(SELECT_HEADER, "select0", method_name, extra_size_bytes, time)
+        self.save_rank_or_select(
+            SELECT_HEADER,
+            "select0",
+            method_name,
+            extra_size_bytes,
+            time,
+        )
     }
 
     /// Returns random number generator.
-    fn rand_gen(&self) -> XorShift64 { XorShift64(self.seed.get()) }
+    fn rand_gen(&self) -> XorShift64 {
+        XorShift64(self.seed.get())
+    }
 
     /// Returns query points drawn uniformly at random from the range [0, `query_universe`).
     fn rand_queries(&self, query_universe: usize) -> Box<[usize]> {
-        self.rand_gen().take(self.queries.get() as usize).map(|v| v as usize % query_universe).collect()
+        self.rand_gen()
+            .take(self.queries.get() as usize)
+            .map(|v| v as usize % query_universe)
+            .collect()
     }
 
     /// Measures and returns average time (in seconds) per `f` call. Cools down and warms up before measurements.
-    #[inline(always)] fn measure<F>(&self, f: F) -> f64
-     where F: Fn()
+    #[inline(always)]
+    fn measure<F>(&self, f: F) -> f64
+    where
+        F: Fn(),
     {
         if self.cooling_time > 0 {
             std::thread::sleep(std::time::Duration::from_secs(self.cooling_time as u64));
@@ -382,21 +541,31 @@ impl Conf {
             let time = Instant::now();
             loop {
                 f();
-                if time.elapsed().as_secs() > self.time as u64 { break; }
+                if time.elapsed().as_secs() > self.time as u64 {
+                    break;
+                }
                 iters += 1;
             }
         }
         let start_moment = Instant::now();
-        for _ in 0..iters { f(); }
-        return start_moment.elapsed().as_secs_f64() / iters as f64
+        for _ in 0..iters {
+            f();
+        }
+        return start_moment.elapsed().as_secs_f64() / iters as f64;
     }
 
     /// Measures and returns average time (in seconds) per `f` call, when `f` is called for each argument from `queries`.
     /// Cools down and warms up before measurements.
-    #[inline(always)] fn queries_measure<R, F>(&self, queries: &[usize], f: F) -> f64
-    where F: Fn(usize) -> R
+    #[inline(always)]
+    fn queries_measure<R, F>(&self, queries: &[usize], f: F) -> f64
+    where
+        F: Fn(usize) -> R,
     {
-        self.measure(|| for i in queries { black_box(f(*i)); }) / queries.len() as f64
+        self.measure(|| {
+            for i in queries {
+                black_box(f(*i));
+            }
+        }) / queries.len() as f64
     }
 
     /*#[inline(always)]pub fn raport_rank<R, F>(&self, method_name: &str, space_overhead: f64, f: F)
@@ -454,7 +623,9 @@ impl Conf {
     }*/
 }
 
-fn percent_of(overhead: usize, whole: usize) -> f64 { (overhead*100) as f64 / whole as f64 }
+fn percent_of(overhead: usize, whole: usize) -> f64 {
+    (overhead * 100) as f64 / whole as f64
+}
 //fn percent_of_diff(with_overhead: usize, whole: usize) -> f64 { percent_of(with_overhead-whole, whole) }
 
 fn main() {
@@ -462,36 +633,50 @@ fn main() {
     match conf.structure {
         Structure::EliasFano => elias_fano::benchmark(&conf),
         Structure::BitmBV => bitm::benchmark_rank_select(&conf),
-        #[cfg(target_pointer_width = "64")] Structure::SucdsBV => sucds::benchmark_rank9_select(&conf),
-        #[cfg(target_pointer_width = "64")] Structure::SuccinctJacobson => succinct::benchmark_jacobson(&conf),
-        #[cfg(target_pointer_width = "64")] Structure::SuccinctRank9 => succinct::benchmark_rank9(&conf),
+        #[cfg(target_pointer_width = "64")]
+        Structure::SucdsBV => sucds::benchmark_rank9_select(&conf),
+        #[cfg(target_pointer_width = "64")]
+        Structure::SuccinctJacobson => succinct::benchmark_jacobson(&conf),
+        #[cfg(target_pointer_width = "64")]
+        Structure::SuccinctRank9 => succinct::benchmark_rank9(&conf),
         Structure::SuxRank9 => sux::benchmark_rank9(&conf),
-        #[cfg(target_pointer_width = "64")] Structure::SuxRankSmallU64v2 => sux::benchmark_rank_small_u64_2(&conf),
-        #[cfg(target_pointer_width = "64")] Structure::SuxRankSmallU64v3 => sux::benchmark_rank_small_u64_3(&conf),
-        #[cfg(not(target_pointer_width = "64"))] Structure::SuxRankSmallU32v3 => sux::benchmark_rank_small_u32_3(&conf),
-        #[cfg(not(target_pointer_width = "64"))] Structure::SuxRankSmallU32v4 => sux::benchmark_rank_small_u32_4(&conf),
+        #[cfg(target_pointer_width = "64")]
+        Structure::SuxRankSmallU64v2 => sux::benchmark_rank_small_u64_2(&conf),
+        #[cfg(target_pointer_width = "64")]
+        Structure::SuxRankSmallU64v3 => sux::benchmark_rank_small_u64_3(&conf),
+        #[cfg(not(target_pointer_width = "64"))]
+        Structure::SuxRankSmallU32v3 => sux::benchmark_rank_small_u32_3(&conf),
+        #[cfg(not(target_pointer_width = "64"))]
+        Structure::SuxRankSmallU32v4 => sux::benchmark_rank_small_u32_4(&conf),
         Structure::SuxSelectAdapt => sux::benchmark_select_adapt(&conf),
-        Structure::SuxSelectAdaptM1 => sux::benchmark_select_adapt_m1(&conf),
-        Structure::SuxSelectAdaptM2 => sux::benchmark_select_adapt_m2(&conf),
+        Structure::SuxSelectAdaptP1 => sux::benchmark_select_adapt_p1(&conf),
+        Structure::SuxSelectAdaptP2 => sux::benchmark_select_adapt_p2(&conf),
         Structure::SuxSelectAdaptConst => sux::benchmark_select_adapt_const(&conf),
-        #[cfg(feature = "vers-vecs")] Structure::Vers => vers::benchmark_rank_select(&conf),
+        #[cfg(feature = "vers-vecs")]
+        Structure::Vers => vers::benchmark_rank_select(&conf),
         Structure::BV => {
             bitm::benchmark_rank_select(&conf);
-            #[cfg(target_pointer_width = "64")] {
-            sucds::benchmark_rank9_select(&conf);
-            succinct::benchmark_rank9(&conf);
-            succinct::benchmark_jacobson(&conf);
+            #[cfg(target_pointer_width = "64")]
+            {
+                sucds::benchmark_rank9_select(&conf);
+                succinct::benchmark_rank9(&conf);
+                succinct::benchmark_jacobson(&conf);
             }
-            #[cfg(feature = "vers-vecs")] vers::benchmark_rank_select(&conf);
+            #[cfg(feature = "vers-vecs")]
+            vers::benchmark_rank_select(&conf);
             sux::benchmark_rank9(&conf);
-            #[cfg(target_pointer_width = "64")] sux::benchmark_rank_small_u64_2(&conf);
-            #[cfg(target_pointer_width = "64")] sux::benchmark_rank_small_u64_3(&conf);
-            #[cfg(not(target_pointer_width = "64"))] sux::benchmark_rank_small_u32_3(&conf);
-            #[cfg(not(target_pointer_width = "64"))] sux::benchmark_rank_small_u32_4(&conf);
+            #[cfg(target_pointer_width = "64")]
+            sux::benchmark_rank_small_u64_2(&conf);
+            #[cfg(target_pointer_width = "64")]
+            sux::benchmark_rank_small_u64_3(&conf);
+            #[cfg(not(target_pointer_width = "64"))]
+            sux::benchmark_rank_small_u32_3(&conf);
+            #[cfg(not(target_pointer_width = "64"))]
+            sux::benchmark_rank_small_u32_4(&conf);
             sux::benchmark_select_adapt(&conf);
-            sux::benchmark_select_adapt_m1(&conf);
-            sux::benchmark_select_adapt_m2(&conf);
+            sux::benchmark_select_adapt_p1(&conf);
+            sux::benchmark_select_adapt_p2(&conf);
             sux::benchmark_select_adapt_const(&conf);
-        },
+        }
     }
 }

--- a/cseq_benchmark/src/main.rs
+++ b/cseq_benchmark/src/main.rs
@@ -43,22 +43,22 @@ pub enum Structure {
     SuccinctRank9,
     /// Rank9 on uncompressed bit vector using sux crate
     SuxRank9,
-    /// RsSmall[u64:2] on uncompressed bit vector using sux crate
-    #[cfg(target_pointer_width = "64")]
-    #[clap(visible_alias = "sux-rs-u64-2")]
-    SuxRsSmallU64v2,
     /// RsSmall[u64:3] on uncompressed bit vector using sux crate
     #[cfg(target_pointer_width = "64")]
     #[clap(visible_alias = "sux-rs-u64-3")]
     SuxRsSmallU64v3,
-    /// RsSmall[u32:3] on uncompressed bit vector using sux crate
-    #[cfg(not(target_pointer_width = "64"))]
-    #[clap(visible_alias = "sux-rs-u32-3")]
-    SuxRsSmallU32v3,
+    /// RsSmall[u64:4] on uncompressed bit vector using sux crate
+    #[cfg(target_pointer_width = "64")]
+    #[clap(visible_alias = "sux-rs-u64-4")]
+    SuxRsSmallU64v4,
     /// RsSmall[u32:4] on uncompressed bit vector using sux crate
     #[cfg(not(target_pointer_width = "64"))]
     #[clap(visible_alias = "sux-rs-u32-4")]
     SuxRsSmallU32v4,
+    /// RsSmall[u32:5] on uncompressed bit vector using sux crate
+    #[cfg(not(target_pointer_width = "64"))]
+    #[clap(visible_alias = "sux-rs-u32-5")]
+    SuxRsSmallU32v5,
     /// SelectAdapt (default) on uncompressed bit vector using sux crate
     #[clap(visible_alias = "sux-adapt")]
     SuxSelectAdapt,
@@ -641,13 +641,13 @@ fn main() {
         Structure::SuccinctRank9 => succinct::benchmark_rank9(&conf),
         Structure::SuxRank9 => sux::benchmark_rank9(&conf),
         #[cfg(target_pointer_width = "64")]
-        Structure::SuxRsSmallU64v2 => sux::benchmark_rs_small_u64_2(&conf),
-        #[cfg(target_pointer_width = "64")]
         Structure::SuxRsSmallU64v3 => sux::benchmark_rs_small_u64_3(&conf),
-        #[cfg(not(target_pointer_width = "64"))]
-        Structure::SuxRsSmallU32v3 => sux::benchmark_rs_small_u32_3(&conf),
+        #[cfg(target_pointer_width = "64")]
+        Structure::SuxRsSmallU64v4 => sux::benchmark_rs_small_u64_4(&conf),
         #[cfg(not(target_pointer_width = "64"))]
         Structure::SuxRsSmallU32v4 => sux::benchmark_rs_small_u32_4(&conf),
+        #[cfg(not(target_pointer_width = "64"))]
+        Structure::SuxRsSmallU32v5 => sux::benchmark_rs_small_u32_5(&conf),
         Structure::SuxSelectAdapt => sux::benchmark_select_adapt(&conf),
         Structure::SuxSelectAdaptSparser => sux::benchmark_select_adapt_sparser(&conf),
         Structure::SuxSelectAdaptSparsest => sux::benchmark_select_adapt_sparsest(&conf),
@@ -666,13 +666,13 @@ fn main() {
             vers::benchmark_rank_select(&conf);
             sux::benchmark_rank9(&conf);
             #[cfg(target_pointer_width = "64")]
-            sux::benchmark_rs_small_u64_2(&conf);
-            #[cfg(target_pointer_width = "64")]
             sux::benchmark_rs_small_u64_3(&conf);
-            #[cfg(not(target_pointer_width = "64"))]
-            sux::benchmark_rs_small_u32_3(&conf);
+            #[cfg(target_pointer_width = "64")]
+            sux::benchmark_rs_small_u64_4(&conf);
             #[cfg(not(target_pointer_width = "64"))]
             sux::benchmark_rs_small_u32_4(&conf);
+            #[cfg(not(target_pointer_width = "64"))]
+            sux::benchmark_rs_small_u32_5(&conf);
             sux::benchmark_select_adapt(&conf);
             sux::benchmark_select_adapt_sparser(&conf);
             sux::benchmark_select_adapt_sparsest(&conf);

--- a/cseq_benchmark/src/sux.rs
+++ b/cseq_benchmark/src/sux.rs
@@ -37,6 +37,24 @@ pub fn benchmark_rank9(conf: &Conf) {
 }
 
 #[cfg(target_pointer_width = "64")]
+pub fn benchmark_rs_small_u64_2(conf: &Conf) {
+    println!("sux RsSmall[u64:2]:");
+    let (content, tester) = build_bit_vec_u64(conf);
+    let rs = rank_small![u64: 2; content];
+    let rs_size = rs.mem_size(Default::default());
+    tester.raport_rank("sux RsSmall[u64:2]", rs_size, |index| rs.rank(index));
+    let sel = SelectSmall::<1, 10, _>::new(rs);
+    tester.raport_select1("sux RsSmall[u64:2]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_unchecked(rank) });
+    let rs = sel.into_inner();
+    let sel = SelectZeroSmall::<1, 10, _>::new(rs);
+    tester.raport_select0("sux RsSmall[u64:2]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_zero_unchecked(rank) });
+}
+
+#[cfg(target_pointer_width = "64")]
 pub fn benchmark_rs_small_u64_3(conf: &Conf) {
     println!("sux RsSmall[u64:3]:");
     let (content, tester) = build_bit_vec_u64(conf);
@@ -68,6 +86,24 @@ pub fn benchmark_rs_small_u64_4(conf: &Conf) {
     let rs = sel.into_inner();
     let sel = SelectZeroSmall::<3, 13, _>::new(rs);
     tester.raport_select0("sux RsSmall[u64:4]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_zero_unchecked(rank) });
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+pub fn benchmark_rs_small_u32_3(conf: &Conf) {
+    println!("sux RsSmall[u32:3]:");
+    let (content, tester) = build_bit_vec_u32(conf);
+    let rs = rank_small![u32: 3; content];
+    let rs_size = rs.mem_size(Default::default());
+    tester.raport_rank("sux RsSmall[u32:3]", rs_size, |index| rs.rank(index));
+    let sel = SelectSmall::<1, 10, _>::new(rs);
+    tester.raport_select1("sux RsSmall[u32:3]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_unchecked(rank) });
+    let rs = sel.into_inner();
+    let sel = SelectZeroSmall::<1, 10, _>::new(rs);
+    tester.raport_select0("sux RsSmall[u32:3]",
         sel.mem_size(Default::default()) - rs_size,
         |rank| unsafe { sel.select_zero_unchecked(rank) });
 }

--- a/cseq_benchmark/src/sux.rs
+++ b/cseq_benchmark/src/sux.rs
@@ -2,7 +2,8 @@ use crate::{Conf, Tester};
 use mem_dbg::MemSize;
 use sux::{
     bits::BitVec,
-    rank_sel::{Rank9, SelectAdapt, SelectAdaptConst, SelectZeroAdapt, SelectZeroAdaptConst,
+    rank_sel::{Rank9, SelectAdapt, SelectAdaptConst, SelectSmall, SelectZeroAdapt,
+        SelectZeroAdaptConst, SelectZeroSmall,
         default_target_inventory_span, DEFAULT_LOG2_WORDS_PER_SUBINVENTORY},
     traits::{BitVecOpsMut, Rank, SelectUnchecked, SelectZeroUnchecked},
 };
@@ -36,39 +37,75 @@ pub fn benchmark_rank9(conf: &Conf) {
 }
 
 #[cfg(target_pointer_width = "64")]
-pub fn benchmark_rank_small_u64_2(conf: &Conf) {
-    println!("sux RankSmall[u64:2]:");
+pub fn benchmark_rs_small_u64_2(conf: &Conf) {
+    println!("sux RsSmall[u64:2]:");
     let (content, tester) = build_bit_vec_u64(conf);
     let rs = rank_small![u64: 2; content];
-    tester.raport_rank("sux RankSmall[u64:2]", rs.mem_size(Default::default()),
-        |index| rs.rank(index));
+    let rs_size = rs.mem_size(Default::default());
+    tester.raport_rank("sux RsSmall[u64:2]", rs_size, |index| rs.rank(index));
+    let sel = SelectSmall::<1, 10, _>::new(rs);
+    tester.raport_select1("sux RsSmall[u64:2]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_unchecked(rank) });
+    let rs = sel.into_inner();
+    let sel = SelectZeroSmall::<1, 10, _>::new(rs);
+    tester.raport_select0("sux RsSmall[u64:2]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_zero_unchecked(rank) });
 }
 
 #[cfg(target_pointer_width = "64")]
-pub fn benchmark_rank_small_u64_3(conf: &Conf) {
-    println!("sux RankSmall[u64:3]:");
+pub fn benchmark_rs_small_u64_3(conf: &Conf) {
+    println!("sux RsSmall[u64:3]:");
     let (content, tester) = build_bit_vec_u64(conf);
     let rs = rank_small![u64: 3; content];
-    tester.raport_rank("sux RankSmall[u64:3]", rs.mem_size(Default::default()),
-        |index| rs.rank(index));
+    let rs_size = rs.mem_size(Default::default());
+    tester.raport_rank("sux RsSmall[u64:3]", rs_size, |index| rs.rank(index));
+    let sel = SelectSmall::<1, 11, _>::new(rs);
+    tester.raport_select1("sux RsSmall[u64:3]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_unchecked(rank) });
+    let rs = sel.into_inner();
+    let sel = SelectZeroSmall::<1, 11, _>::new(rs);
+    tester.raport_select0("sux RsSmall[u64:3]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_zero_unchecked(rank) });
 }
 
 #[cfg(not(target_pointer_width = "64"))]
-pub fn benchmark_rank_small_u32_3(conf: &Conf) {
-    println!("sux RankSmall[u32:3]:");
+pub fn benchmark_rs_small_u32_3(conf: &Conf) {
+    println!("sux RsSmall[u32:3]:");
     let (content, tester) = build_bit_vec_u32(conf);
     let rs = rank_small![u32: 3; content];
-    tester.raport_rank("sux RankSmall[u32:3]", rs.mem_size(Default::default()),
-        |index| rs.rank(index));
+    let rs_size = rs.mem_size(Default::default());
+    tester.raport_rank("sux RsSmall[u32:3]", rs_size, |index| rs.rank(index));
+    let sel = SelectSmall::<1, 10, _>::new(rs);
+    tester.raport_select1("sux RsSmall[u32:3]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_unchecked(rank) });
+    let rs = sel.into_inner();
+    let sel = SelectZeroSmall::<1, 10, _>::new(rs);
+    tester.raport_select0("sux RsSmall[u32:3]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_zero_unchecked(rank) });
 }
 
 #[cfg(not(target_pointer_width = "64"))]
-pub fn benchmark_rank_small_u32_4(conf: &Conf) {
-    println!("sux RankSmall[u32:4]:");
+pub fn benchmark_rs_small_u32_4(conf: &Conf) {
+    println!("sux RsSmall[u32:4]:");
     let (content, tester) = build_bit_vec_u32(conf);
     let rs = rank_small![u32: 4; content];
-    tester.raport_rank("sux RankSmall[u32:4]", rs.mem_size(Default::default()),
-        |index| rs.rank(index));
+    let rs_size = rs.mem_size(Default::default());
+    tester.raport_rank("sux RsSmall[u32:4]", rs_size, |index| rs.rank(index));
+    let sel = SelectSmall::<1, 11, _>::new(rs);
+    tester.raport_select1("sux RsSmall[u32:4]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_unchecked(rank) });
+    let rs = sel.into_inner();
+    let sel = SelectZeroSmall::<1, 11, _>::new(rs);
+    tester.raport_select0("sux RsSmall[u32:4]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_zero_unchecked(rank) });
 }
 
 pub fn benchmark_select_adapt(conf: &Conf) {

--- a/cseq_benchmark/src/sux.rs
+++ b/cseq_benchmark/src/sux.rs
@@ -5,7 +5,7 @@ use sux::{
     rank_sel::{Rank9, SelectAdapt, SelectAdaptConst, SelectSmall, SelectZeroAdapt,
         SelectZeroAdaptConst, SelectZeroSmall,
         default_target_inventory_span, DEFAULT_LOG2_WORDS_PER_SUBINVENTORY},
-    traits::{BitVecOpsMut, Rank, SelectUnchecked, SelectZeroUnchecked},
+    traits::{BitVecOpsMut, RankUnchecked, SelectUnchecked, SelectZeroUnchecked},
 };
 use sux::rank_small;
 
@@ -33,7 +33,7 @@ pub fn benchmark_rank9(conf: &Conf) {
     let (content, tester) = build_bit_vec_u64(conf);
     let rs = Rank9::new(content);
     tester.raport_rank("sux Rank9", rs.mem_size(Default::default()),
-        |index| rs.rank(index));
+        |index| unsafe { rs.rank_unchecked(index) });
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -42,7 +42,7 @@ pub fn benchmark_rs_small_u64_2(conf: &Conf) {
     let (content, tester) = build_bit_vec_u64(conf);
     let rs = rank_small![u64: 2; content];
     let rs_size = rs.mem_size(Default::default());
-    tester.raport_rank("sux RsSmall[u64:2]", rs_size, |index| rs.rank(index));
+    tester.raport_rank("sux RsSmall[u64:2]", rs_size, |index| unsafe { rs.rank_unchecked(index) });
     let sel = SelectSmall::<1, 10, _>::new(rs);
     tester.raport_select1("sux RsSmall[u64:2]",
         sel.mem_size(Default::default()) - rs_size,
@@ -60,7 +60,7 @@ pub fn benchmark_rs_small_u64_3(conf: &Conf) {
     let (content, tester) = build_bit_vec_u64(conf);
     let rs = rank_small![u64: 3; content];
     let rs_size = rs.mem_size(Default::default());
-    tester.raport_rank("sux RsSmall[u64:3]", rs_size, |index| rs.rank(index));
+    tester.raport_rank("sux RsSmall[u64:3]", rs_size, |index| unsafe { rs.rank_unchecked(index) });
     let sel = SelectSmall::<1, 11, _>::new(rs);
     tester.raport_select1("sux RsSmall[u64:3]",
         sel.mem_size(Default::default()) - rs_size,
@@ -78,7 +78,7 @@ pub fn benchmark_rs_small_u64_4(conf: &Conf) {
     let (content, tester) = build_bit_vec_u64(conf);
     let rs = rank_small![u64: 4; content];
     let rs_size = rs.mem_size(Default::default());
-    tester.raport_rank("sux RsSmall[u64:4]", rs_size, |index| rs.rank(index));
+    tester.raport_rank("sux RsSmall[u64:4]", rs_size, |index| unsafe { rs.rank_unchecked(index) });
     let sel = SelectSmall::<3, 13, _>::new(rs);
     tester.raport_select1("sux RsSmall[u64:4]",
         sel.mem_size(Default::default()) - rs_size,
@@ -96,7 +96,7 @@ pub fn benchmark_rs_small_u32_3(conf: &Conf) {
     let (content, tester) = build_bit_vec_u32(conf);
     let rs = rank_small![u32: 3; content];
     let rs_size = rs.mem_size(Default::default());
-    tester.raport_rank("sux RsSmall[u32:3]", rs_size, |index| rs.rank(index));
+    tester.raport_rank("sux RsSmall[u32:3]", rs_size, |index| unsafe { rs.rank_unchecked(index) });
     let sel = SelectSmall::<1, 10, _>::new(rs);
     tester.raport_select1("sux RsSmall[u32:3]",
         sel.mem_size(Default::default()) - rs_size,
@@ -114,7 +114,7 @@ pub fn benchmark_rs_small_u32_4(conf: &Conf) {
     let (content, tester) = build_bit_vec_u32(conf);
     let rs = rank_small![u32: 4; content];
     let rs_size = rs.mem_size(Default::default());
-    tester.raport_rank("sux RsSmall[u32:4]", rs_size, |index| rs.rank(index));
+    tester.raport_rank("sux RsSmall[u32:4]", rs_size, |index| unsafe { rs.rank_unchecked(index) });
     let sel = SelectSmall::<1, 11, _>::new(rs);
     tester.raport_select1("sux RsSmall[u32:4]",
         sel.mem_size(Default::default()) - rs_size,
@@ -132,7 +132,7 @@ pub fn benchmark_rs_small_u32_5(conf: &Conf) {
     let (content, tester) = build_bit_vec_u32(conf);
     let rs = rank_small![u32: 5; content];
     let rs_size = rs.mem_size(Default::default());
-    tester.raport_rank("sux RsSmall[u32:5]", rs_size, |index| rs.rank(index));
+    tester.raport_rank("sux RsSmall[u32:5]", rs_size, |index| unsafe { rs.rank_unchecked(index) });
     let sel = SelectSmall::<3, 13, _>::new(rs);
     tester.raport_select1("sux RsSmall[u32:5]",
         sel.mem_size(Default::default()) - rs_size,

--- a/cseq_benchmark/src/sux.rs
+++ b/cseq_benchmark/src/sux.rs
@@ -1,12 +1,74 @@
-use mem_dbg::MemSize;
-use sux::{bits::BitVec, rank_sel::{SelectAdapt, SelectAdaptConst, SelectZeroAdapt, SelectZeroAdaptConst},
-    traits::{SelectUnchecked, SelectZeroUnchecked}};
 use crate::{Conf, Tester};
+use mem_dbg::MemSize;
+use sux::{
+    bits::BitVec,
+    rank_sel::{Rank9, SelectAdapt, SelectAdaptConst, SelectZeroAdapt, SelectZeroAdaptConst,
+        default_target_inventory_span, DEFAULT_LOG2_WORDS_PER_SUBINVENTORY},
+    traits::{BitVecOpsMut, Rank, SelectUnchecked, SelectZeroUnchecked},
+};
+use sux::rank_small;
 
 pub fn build_bit_vec(conf: &'_ Conf) -> (BitVec, Tester<'_>) {
-    let mut content = BitVec::new(conf.universe);
+    let mut content: BitVec = BitVec::new(conf.universe);
     let tester = conf.fill_data(|bit_nr, value| content.set(bit_nr, value));
     (content, tester)
+}
+
+fn build_bit_vec_u64(conf: &'_ Conf) -> (BitVec<Vec<u64>>, Tester<'_>) {
+    let mut content: BitVec<Vec<u64>> = BitVec::new(conf.universe);
+    let tester = conf.fill_data(|bit_nr, value| content.set(bit_nr, value));
+    (content, tester)
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+fn build_bit_vec_u32(conf: &'_ Conf) -> (BitVec<Vec<u32>>, Tester<'_>) {
+    let mut content: BitVec<Vec<u32>> = BitVec::new(conf.universe);
+    let tester = conf.fill_data(|bit_nr, value| content.set(bit_nr, value));
+    (content, tester)
+}
+
+pub fn benchmark_rank9(conf: &Conf) {
+    println!("sux Rank9:");
+    let (content, tester) = build_bit_vec_u64(conf);
+    let rs = Rank9::new(content);
+    tester.raport_rank("sux Rank9", rs.mem_size(Default::default()),
+        |index| rs.rank(index));
+}
+
+#[cfg(target_pointer_width = "64")]
+pub fn benchmark_rank_small_u64_2(conf: &Conf) {
+    println!("sux RankSmall[u64:2]:");
+    let (content, tester) = build_bit_vec_u64(conf);
+    let rs = rank_small![u64: 2; content];
+    tester.raport_rank("sux RankSmall[u64:2]", rs.mem_size(Default::default()),
+        |index| rs.rank(index));
+}
+
+#[cfg(target_pointer_width = "64")]
+pub fn benchmark_rank_small_u64_3(conf: &Conf) {
+    println!("sux RankSmall[u64:3]:");
+    let (content, tester) = build_bit_vec_u64(conf);
+    let rs = rank_small![u64: 3; content];
+    tester.raport_rank("sux RankSmall[u64:3]", rs.mem_size(Default::default()),
+        |index| rs.rank(index));
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+pub fn benchmark_rank_small_u32_3(conf: &Conf) {
+    println!("sux RankSmall[u32:3]:");
+    let (content, tester) = build_bit_vec_u32(conf);
+    let rs = rank_small![u32: 3; content];
+    tester.raport_rank("sux RankSmall[u32:3]", rs.mem_size(Default::default()),
+        |index| rs.rank(index));
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+pub fn benchmark_rank_small_u32_4(conf: &Conf) {
+    println!("sux RankSmall[u32:4]:");
+    let (content, tester) = build_bit_vec_u32(conf);
+    let rs = rank_small![u32: 4; content];
+    tester.raport_rank("sux RankSmall[u32:4]", rs.mem_size(Default::default()),
+        |index| rs.rank(index));
 }
 
 pub fn benchmark_select_adapt(conf: &Conf) {
@@ -15,18 +77,76 @@ pub fn benchmark_select_adapt(conf: &Conf) {
     let (mut content, tester) = build_bit_vec(conf);
     let content_size = content.mem_size(Default::default());
 
-    let rs = SelectAdapt::new(content, 3);
-    //rs.mem_dbg(Default::default()).unwrap();
-    tester.raport_select1("sux SelectAdapt",
+    let rs = SelectAdapt::with_span(content,
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY),
+        DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
+    tester.raport_select1(
+        "sux SelectAdapt",
         rs.mem_size(Default::default()) - content_size,
-        |rank| unsafe { rs.select_unchecked(rank) });
+        |rank| unsafe { rs.select_unchecked(rank) },
+    );
 
     content = rs.into_inner();
-    let rs = SelectZeroAdapt::new(content, 3);
-    //rs.mem_dbg(Default::default()).unwrap();
-    tester.raport_select0("sux SelectAdapt",
-            rs.mem_size(Default::default()) - content_size,
-            |rank| unsafe { rs.select_zero_unchecked(rank) });
+    let rs = SelectZeroAdapt::with_span(content,
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY),
+        DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
+    tester.raport_select0(
+        "sux SelectAdapt",
+        rs.mem_size(Default::default()) - content_size,
+        |rank| unsafe { rs.select_zero_unchecked(rank) },
+    );
+}
+
+pub fn benchmark_select_adapt_m1(conf: &Conf) {
+    println!("sux SelectAdapt (span-1):");
+
+    let (mut content, tester) = build_bit_vec(conf);
+    let content_size = content.mem_size(Default::default());
+
+    let rs = SelectAdapt::with_span(content,
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY - 1),
+        DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
+    tester.raport_select1(
+        "sux SelectAdapt (span-1)",
+        rs.mem_size(Default::default()) - content_size,
+        |rank| unsafe { rs.select_unchecked(rank) },
+    );
+
+    content = rs.into_inner();
+    let rs = SelectZeroAdapt::with_span(content,
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY - 1),
+        DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
+    tester.raport_select0(
+        "sux SelectAdapt (span-1)",
+        rs.mem_size(Default::default()) - content_size,
+        |rank| unsafe { rs.select_zero_unchecked(rank) },
+    );
+}
+
+pub fn benchmark_select_adapt_m2(conf: &Conf) {
+    println!("sux SelectAdapt (span-2):");
+
+    let (mut content, tester) = build_bit_vec(conf);
+    let content_size = content.mem_size(Default::default());
+
+    let rs = SelectAdapt::with_span(content,
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY - 2),
+        DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
+    tester.raport_select1(
+        "sux SelectAdapt (span-2)",
+        rs.mem_size(Default::default()) - content_size,
+        |rank| unsafe { rs.select_unchecked(rank) },
+    );
+
+    content = rs.into_inner();
+    let rs = SelectZeroAdapt::with_span(content,
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY - 2),
+        DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
+    tester.raport_select0(
+        "sux SelectAdapt (span-2)",
+        rs.mem_size(Default::default()) - content_size,
+        |rank| unsafe { rs.select_zero_unchecked(rank) },
+    );
 }
 
 pub fn benchmark_select_adapt_const(conf: &Conf) {
@@ -35,16 +155,20 @@ pub fn benchmark_select_adapt_const(conf: &Conf) {
     let (mut content, tester) = build_bit_vec(conf);
     let content_size = content.mem_size(Default::default());
 
-    let rs = SelectAdaptConst::<_,_>::new(content);
+    let rs = SelectAdaptConst::<_, _>::new(content);
     //rs.mem_dbg(Default::default()).unwrap();
-    tester.raport_select1("sux SelectAdaptConst",
+    tester.raport_select1(
+        "sux SelectAdaptConst",
         rs.mem_size(Default::default()) - content_size,
-        |rank| unsafe { rs.select_unchecked(rank) });
+        |rank| unsafe { rs.select_unchecked(rank) },
+    );
 
     content = rs.into_inner();
-    let rs = SelectZeroAdaptConst::<_,_>::new(content);
+    let rs = SelectZeroAdaptConst::<_, _>::new(content);
     //rs.mem_dbg(Default::default()).unwrap();
-    tester.raport_select0("sux SelectAdaptConst",
-            rs.mem_size(Default::default()) - content_size,
-            |rank| unsafe { rs.select_zero_unchecked(rank) });
+    tester.raport_select0(
+        "sux SelectAdaptConst",
+        rs.mem_size(Default::default()) - content_size,
+        |rank| unsafe { rs.select_zero_unchecked(rank) },
+    );
 }

--- a/cseq_benchmark/src/sux.rs
+++ b/cseq_benchmark/src/sux.rs
@@ -37,24 +37,6 @@ pub fn benchmark_rank9(conf: &Conf) {
 }
 
 #[cfg(target_pointer_width = "64")]
-pub fn benchmark_rs_small_u64_2(conf: &Conf) {
-    println!("sux RsSmall[u64:2]:");
-    let (content, tester) = build_bit_vec_u64(conf);
-    let rs = rank_small![u64: 2; content];
-    let rs_size = rs.mem_size(Default::default());
-    tester.raport_rank("sux RsSmall[u64:2]", rs_size, |index| rs.rank(index));
-    let sel = SelectSmall::<1, 10, _>::new(rs);
-    tester.raport_select1("sux RsSmall[u64:2]",
-        sel.mem_size(Default::default()) - rs_size,
-        |rank| unsafe { sel.select_unchecked(rank) });
-    let rs = sel.into_inner();
-    let sel = SelectZeroSmall::<1, 10, _>::new(rs);
-    tester.raport_select0("sux RsSmall[u64:2]",
-        sel.mem_size(Default::default()) - rs_size,
-        |rank| unsafe { sel.select_zero_unchecked(rank) });
-}
-
-#[cfg(target_pointer_width = "64")]
 pub fn benchmark_rs_small_u64_3(conf: &Conf) {
     println!("sux RsSmall[u64:3]:");
     let (content, tester) = build_bit_vec_u64(conf);
@@ -72,20 +54,20 @@ pub fn benchmark_rs_small_u64_3(conf: &Conf) {
         |rank| unsafe { sel.select_zero_unchecked(rank) });
 }
 
-#[cfg(not(target_pointer_width = "64"))]
-pub fn benchmark_rs_small_u32_3(conf: &Conf) {
-    println!("sux RsSmall[u32:3]:");
-    let (content, tester) = build_bit_vec_u32(conf);
-    let rs = rank_small![u32: 3; content];
+#[cfg(target_pointer_width = "64")]
+pub fn benchmark_rs_small_u64_4(conf: &Conf) {
+    println!("sux RsSmall[u64:4]:");
+    let (content, tester) = build_bit_vec_u64(conf);
+    let rs = rank_small![u64: 4; content];
     let rs_size = rs.mem_size(Default::default());
-    tester.raport_rank("sux RsSmall[u32:3]", rs_size, |index| rs.rank(index));
-    let sel = SelectSmall::<1, 10, _>::new(rs);
-    tester.raport_select1("sux RsSmall[u32:3]",
+    tester.raport_rank("sux RsSmall[u64:4]", rs_size, |index| rs.rank(index));
+    let sel = SelectSmall::<3, 13, _>::new(rs);
+    tester.raport_select1("sux RsSmall[u64:4]",
         sel.mem_size(Default::default()) - rs_size,
         |rank| unsafe { sel.select_unchecked(rank) });
     let rs = sel.into_inner();
-    let sel = SelectZeroSmall::<1, 10, _>::new(rs);
-    tester.raport_select0("sux RsSmall[u32:3]",
+    let sel = SelectZeroSmall::<3, 13, _>::new(rs);
+    tester.raport_select0("sux RsSmall[u64:4]",
         sel.mem_size(Default::default()) - rs_size,
         |rank| unsafe { sel.select_zero_unchecked(rank) });
 }
@@ -104,6 +86,24 @@ pub fn benchmark_rs_small_u32_4(conf: &Conf) {
     let rs = sel.into_inner();
     let sel = SelectZeroSmall::<1, 11, _>::new(rs);
     tester.raport_select0("sux RsSmall[u32:4]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_zero_unchecked(rank) });
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+pub fn benchmark_rs_small_u32_5(conf: &Conf) {
+    println!("sux RsSmall[u32:5]:");
+    let (content, tester) = build_bit_vec_u32(conf);
+    let rs = rank_small![u32: 5; content];
+    let rs_size = rs.mem_size(Default::default());
+    tester.raport_rank("sux RsSmall[u32:5]", rs_size, |index| rs.rank(index));
+    let sel = SelectSmall::<3, 13, _>::new(rs);
+    tester.raport_select1("sux RsSmall[u32:5]",
+        sel.mem_size(Default::default()) - rs_size,
+        |rank| unsafe { sel.select_unchecked(rank) });
+    let rs = sel.into_inner();
+    let sel = SelectZeroSmall::<3, 13, _>::new(rs);
+    tester.raport_select0("sux RsSmall[u32:5]",
         sel.mem_size(Default::default()) - rs_size,
         |rank| unsafe { sel.select_zero_unchecked(rank) });
 }

--- a/cseq_benchmark/src/sux.rs
+++ b/cseq_benchmark/src/sux.rs
@@ -97,7 +97,7 @@ pub fn benchmark_select_adapt(conf: &Conf) {
     );
 }
 
-pub fn benchmark_select_adapt_p1(conf: &Conf) {
+pub fn benchmark_select_adapt_sparser(conf: &Conf) {
     println!("sux SelectAdapt (sparser):");
 
     let (mut content, tester) = build_bit_vec(conf);
@@ -123,7 +123,7 @@ pub fn benchmark_select_adapt_p1(conf: &Conf) {
     );
 }
 
-pub fn benchmark_select_adapt_p2(conf: &Conf) {
+pub fn benchmark_select_adapt_sparsest(conf: &Conf) {
     println!("sux SelectAdapt (sparsest):");
 
     let (mut content, tester) = build_bit_vec(conf);

--- a/cseq_benchmark/src/sux.rs
+++ b/cseq_benchmark/src/sux.rs
@@ -97,53 +97,53 @@ pub fn benchmark_select_adapt(conf: &Conf) {
     );
 }
 
-pub fn benchmark_select_adapt_m1(conf: &Conf) {
-    println!("sux SelectAdapt (span-1):");
+pub fn benchmark_select_adapt_p1(conf: &Conf) {
+    println!("sux SelectAdapt (sparser):");
 
     let (mut content, tester) = build_bit_vec(conf);
     let content_size = content.mem_size(Default::default());
 
     let rs = SelectAdapt::with_span(content,
-        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY - 1),
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY + 1),
         DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
     tester.raport_select1(
-        "sux SelectAdapt (span-1)",
+        "sux SelectAdapt (sparser)",
         rs.mem_size(Default::default()) - content_size,
         |rank| unsafe { rs.select_unchecked(rank) },
     );
 
     content = rs.into_inner();
     let rs = SelectZeroAdapt::with_span(content,
-        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY - 1),
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY + 1),
         DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
     tester.raport_select0(
-        "sux SelectAdapt (span-1)",
+        "sux SelectAdapt (sparser)",
         rs.mem_size(Default::default()) - content_size,
         |rank| unsafe { rs.select_zero_unchecked(rank) },
     );
 }
 
-pub fn benchmark_select_adapt_m2(conf: &Conf) {
-    println!("sux SelectAdapt (span-2):");
+pub fn benchmark_select_adapt_p2(conf: &Conf) {
+    println!("sux SelectAdapt (sparsest):");
 
     let (mut content, tester) = build_bit_vec(conf);
     let content_size = content.mem_size(Default::default());
 
     let rs = SelectAdapt::with_span(content,
-        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY - 2),
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY + 2),
         DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
     tester.raport_select1(
-        "sux SelectAdapt (span-2)",
+        "sux SelectAdapt (sparsest)",
         rs.mem_size(Default::default()) - content_size,
         |rank| unsafe { rs.select_unchecked(rank) },
     );
 
     content = rs.into_inner();
     let rs = SelectZeroAdapt::with_span(content,
-        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY - 2),
+        default_target_inventory_span(DEFAULT_LOG2_WORDS_PER_SUBINVENTORY + 2),
         DEFAULT_LOG2_WORDS_PER_SUBINVENTORY);
     tester.raport_select0(
-        "sux SelectAdapt (span-2)",
+        "sux SelectAdapt (sparsest)",
         rs.mem_size(Default::default()) - content_size,
         |rank| unsafe { rs.select_zero_unchecked(rank) },
     );


### PR DESCRIPTION
This PR updates the benchmarks to `sux` 0.14.0. There are three variants of `SelectAdapt` and three variants of `RankSmall`. The `cfg`'s for 64-bit have been eliminated as `sux` works also on 32-bit platforms. The `RankSmall` structures, however, have been gated to avoid flooding the CLI.

I have also added a `.cargo/config.toml` to set the native CPU, as it's really a nuisanse to have to add the variable each time you compile, but if you have reasons against it I'll remove it.